### PR TITLE
Update the charge description to match frontend orders

### DIFF
--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -53,7 +53,7 @@ module SolidusStripe
       stripe.create_intent(
         (current_order.total * 100).to_i,
         params[:stripe_payment_method_id],
-        description: "Solidus Order ID: #{current_order.number} (pending)",
+        description: "#{current_order.number} (pending)",
         currency: current_order.currency,
         confirmation_method: 'automatic',
         capture_method: 'manual',

--- a/app/models/solidus_stripe/create_intents_payment_service.rb
+++ b/app/models/solidus_stripe/create_intents_payment_service.rb
@@ -13,7 +13,7 @@ module SolidusStripe
     def call
       invalidate_previous_payment_intents_payments
       if (payment = create_payment)
-        description = "Solidus Order ID: #{payment.gateway_order_identifier}"
+        description = payment.gateway_order_identifier
         stripe.update_intent(nil, intent_id, nil, description: description)
         true
       else
@@ -107,7 +107,7 @@ module SolidusStripe
     end
 
     def update_stripe_payment_description
-      description = "Solidus Order ID: #{payment.gateway_order_identifier}"
+      description = payment.gateway_order_identifier
       stripe.update_intent(nil, intent_id, nil, description: description)
     end
   end

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -152,7 +152,7 @@ module Spree
 
       def options_for_purchase_or_auth(money, creditcard, transaction_options)
         options = {}
-        options[:description] = "Solidus Order ID: #{transaction_options[:order_id]}"
+        options[:description] = transaction_options[:order_id]
         options[:currency] = transaction_options[:currency]
         options[:off_session] = true if v3_intents?
         options[:statement_descriptor_suffix] = transaction_options[:statement_descriptor_suffix] if transaction_options[:statement_descriptor_suffix]


### PR DESCRIPTION
## Summary

Orders created with the OMS have a different charge description in Stripe. This PR is part one of making the charge descriptions align. 

![Image 2022-11-23 at 1 09 11 PM](https://user-images.githubusercontent.com/12205/203646611-8fc8fb11-d3c9-4eb9-9453-0e9b7147c830.jpg)


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
